### PR TITLE
Apply random patches from some unknown source

### DIFF
--- a/include/libssh/libssh.h
+++ b/include/libssh/libssh.h
@@ -400,6 +400,7 @@ enum ssh_options_e {
   SSH_OPTIONS_PROCESS_CONFIG,
   SSH_OPTIONS_REKEY_DATA,
   SSH_OPTIONS_REKEY_TIME,
+  SSH_OPTIONS_OWNS_SOCKET,
 };
 
 enum {
@@ -653,6 +654,7 @@ LIBSSH_API int ssh_key_is_private(const ssh_key k);
 LIBSSH_API int ssh_key_cmp(const ssh_key k1,
                            const ssh_key k2,
                            enum ssh_keycmp_e what);
+LIBSSH_API ssh_key ssh_key_dup(const ssh_key key);
 
 LIBSSH_API int ssh_pki_generate(enum ssh_keytypes_e type, int parameter,
         ssh_key *pkey);
@@ -821,6 +823,9 @@ LIBSSH_API int ssh_buffer_add_data(ssh_buffer buffer, const void *data, uint32_t
 LIBSSH_API uint32_t ssh_buffer_get_data(ssh_buffer buffer, void *data, uint32_t requestedlen);
 LIBSSH_API void *ssh_buffer_get(ssh_buffer buffer);
 LIBSSH_API uint32_t ssh_buffer_get_len(ssh_buffer buffer);
+
+LIBSSH_API int pki_sign_string(ssh_key privkey, ssh_string input, ssh_string* output);
+LIBSSH_API int pki_verify_string(ssh_key pubkey, ssh_string sig_blob, ssh_string input);
 
 #ifndef LIBSSH_LEGACY_0_4
 #include "libssh/legacy.h"

--- a/include/libssh/pki.h
+++ b/include/libssh/pki.h
@@ -101,7 +101,6 @@ struct ssh_signature_struct {
 typedef struct ssh_signature_struct *ssh_signature;
 
 /* SSH Key Functions */
-ssh_key ssh_key_dup(const ssh_key key);
 void ssh_key_clean (ssh_key key);
 
 const char *
@@ -111,6 +110,7 @@ enum ssh_keytypes_e ssh_key_type_from_signature_name(const char *name);
 enum ssh_keytypes_e ssh_key_type_plain(enum ssh_keytypes_e type);
 enum ssh_digest_e ssh_key_type_to_hash(ssh_session session,
                                        enum ssh_keytypes_e type);
+enum ssh_digest_e key_type_to_hash(enum ssh_keytypes_e type);
 enum ssh_digest_e ssh_key_hash_from_name(const char *name);
 
 #define is_ecdsa_key_type(t) \

--- a/include/libssh/session.h
+++ b/include/libssh/session.h
@@ -244,6 +244,7 @@ struct ssh_session_struct {
         uint8_t options_seen[SOC_MAX];
         uint64_t rekey_data;
         uint32_t rekey_time;
+        bool owns_socket;
     } opts;
     /* counters */
     ssh_counter socket_counter;

--- a/include/libssh/socket.h
+++ b/include/libssh/socket.h
@@ -34,6 +34,7 @@ ssh_socket ssh_socket_new(ssh_session session);
 void ssh_socket_reset(ssh_socket s);
 void ssh_socket_free(ssh_socket s);
 void ssh_socket_set_fd(ssh_socket s, socket_t fd);
+int ssh_socket_owns_fd(ssh_socket s);
 socket_t ssh_socket_get_fd(ssh_socket s);
 #ifndef _WIN32
 int ssh_socket_unix(ssh_socket s, const char *path);

--- a/src/options.c
+++ b/src/options.c
@@ -484,6 +484,15 @@ int ssh_options_set(ssh_session session, enum ssh_options_e type,
     }
 
     switch (type) {
+        case SSH_OPTIONS_OWNS_SOCKET:
+            if (value == NULL) {
+                ssh_set_error_invalid(session);
+                return -1;
+            } else {
+                bool *x = (bool *)value;
+                session->opts.owns_socket = *x;
+            }
+            break;
         case SSH_OPTIONS_HOST:
             v = value;
             if (v == NULL || v[0] == '\0') {

--- a/src/pki_crypto.c
+++ b/src/pki_crypto.c
@@ -1373,7 +1373,7 @@ fail:
 
     return NULL;
 }
-
+#ifdef HAVE_DSA
 static ssh_string pki_dsa_signature_to_blob(const ssh_signature sig)
 {
     char buffer[40] = { 0 };
@@ -1459,6 +1459,7 @@ error:
     SSH_STRING_FREE(s);
     return NULL;
 }
+#endif
 
 static ssh_string pki_ecdsa_signature_to_blob(const ssh_signature sig)
 {
@@ -1552,9 +1553,11 @@ ssh_string pki_signature_to_blob(const ssh_signature sig)
     ssh_string sig_blob = NULL;
 
     switch(sig->type) {
+#ifdef HAVE_DSA
         case SSH_KEYTYPE_DSS:
             sig_blob = pki_dsa_signature_to_blob(sig);
             break;
+#endif
         case SSH_KEYTYPE_RSA:
         case SSH_KEYTYPE_RSA1:
             sig_blob = ssh_string_copy(sig->raw_sig);
@@ -1646,7 +1649,7 @@ errout:
     SSH_STRING_FREE(sig_blob_padded);
     return SSH_ERROR;
 }
-
+#ifdef HAVE_DSA
 static int pki_signature_from_dsa_blob(UNUSED_PARAM(const ssh_key pubkey),
                                        const ssh_string sig_blob,
                                        ssh_signature sig)
@@ -1773,7 +1776,7 @@ error:
     DSA_SIG_free(dsa_sig);
     return SSH_ERROR;
 }
-
+#endif
 static int pki_signature_from_ecdsa_blob(UNUSED_PARAM(const ssh_key pubkey),
                                          const ssh_string sig_blob,
                                          ssh_signature sig)
@@ -1938,12 +1941,14 @@ ssh_signature pki_signature_from_blob(const ssh_key pubkey,
     sig->hash_type = hash_type;
 
     switch(type) {
+#ifdef HAVE_DSA
         case SSH_KEYTYPE_DSS:
             rc = pki_signature_from_dsa_blob(pubkey, sig_blob, sig);
             if (rc != SSH_OK) {
                 goto error;
             }
             break;
+#endif
         case SSH_KEYTYPE_RSA:
         case SSH_KEYTYPE_RSA1:
             rc = pki_signature_from_rsa_blob(pubkey, sig_blob, sig);

--- a/src/session.c
+++ b/src/session.c
@@ -108,6 +108,7 @@ ssh_session ssh_new(void)
     session->opts.StrictHostKeyChecking = 1;
     session->opts.port = 0;
     session->opts.fd = -1;
+    session->opts.owns_socket = true;
     session->opts.compressionlevel = 7;
     session->opts.nodelay = 0;
 
@@ -1039,7 +1040,7 @@ int ssh_get_pubkey_hash(ssh_session session, unsigned char **hash)
 /**
  * @brief Deallocate the hash obtained by ssh_get_pubkey_hash.
  *
- * This is required under Microsoft platform as this library might use a 
+ * This is required under Microsoft platform as this library might use a
  * different C library than your software, hence a different heap.
  *
  * @param[in] hash      The buffer to deallocate.


### PR DESCRIPTION
Resolves #6 

When https://github.com/ClickHouse/libssh was created ([PR](https://github.com/ClickHouse/ClickHouse/pull/41109) in ClickHouse repo), some patches were silently integrated into the libssh codebase, without documenting that these patches exist and where they come from. This happened probably in the aftermath of https://github.com/ClickHouse/libssh/pull/1. Using plain upstream libssh breaks compilation ...

This PR splits these random patches at least into a separate PR. I still have no clue if this is a single patch or multiple, and where they come from

We should really really really stop practicing such terrible development practices, especially in security-relevant code.